### PR TITLE
Fix sidebar highlight and convert to client component

### DIFF
--- a/frontend/src/stories/Sidebar.tsx
+++ b/frontend/src/stories/Sidebar.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import React from "react";
+import { usePathname } from "next/navigation";
 
 interface SidebarItem {
   name: string;
@@ -11,6 +14,8 @@ interface SidebarProps {
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ sections, user }) => {
+  const pathname = usePathname();
+
   return (
     <aside className="w-64 bg-white h-screen shadow-md flex flex-col">
       <div className="p-6">
@@ -20,7 +25,9 @@ const Sidebar: React.FC<SidebarProps> = ({ sections, user }) => {
             <a
               key={index}
               href={`/${item.name}`}
-              className="flex items-center p-2 text-gray-700 hover:bg-gray-100 rounded transition"
+              className={`flex items-center p-2 text-gray-700 hover:bg-gray-100 rounded transition ${
+                pathname === `/${item.name}` ? "bg-gray-100" : ""
+              }`}
             >
               <span className="mr-3">
                 <svg
@@ -36,17 +43,33 @@ const Sidebar: React.FC<SidebarProps> = ({ sections, user }) => {
               <span>{item.name}</span>
             </a>
           ))}
+
           <hr className="my-2 border-gray-300" />
-          <a href="/profile" className="flex items-center p-2 text-gray-700 bg-gray-100 rounded">
+
+          {/* ✅ User Profile link */}
+          <a
+            href="/profile"
+            className={`flex items-center p-2 text-gray-700 hover:bg-gray-100 rounded transition ${
+              pathname === "/profile" ? "bg-gray-100" : ""
+            }`}
+          >
             <span className="mr-3">
               <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 20h10M12 4v16m0 0H8m4 0h4" />
               </svg>
             </span>
-           <span>{user.name}</span>
+            <span>{user.name}</span>
           </a>
+
           <hr className="my-2 border-gray-300" />
-          <a href="/settings" className="flex items-center p-2 text-gray-700 hover:bg-gray-100 rounded">
+
+          {/* ✅ Settings link */}
+          <a
+            href="/settings"
+            className={`flex items-center p-2 text-gray-700 hover:bg-gray-100 rounded transition ${
+              pathname === "/settings" ? "bg-gray-100" : ""
+            }`}
+          >
             <span className="mr-3">
               <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 1v3M8.5 2.5l2 2M1 12h3m16 0h3m-9 7l2 2M6.5 21.5l2-2M21 12l2-2M6 9h12v6H6V9z" />


### PR DESCRIPTION
This PR addresses a UI/UX issue where the user profile sidebar item (“john doe”) was highlighted by default on initial load — even when not on the profile page. Additionally, the Sidebar component is now explicitly marked as a client component to support usePathname() from next/navigation.

Changes
	•	Removed default background highlight on user profile sidebar item.
	•	Added logic to apply highlight only when current pathname matches the corresponding route.
	•	Converted Sidebar.tsx to a client component using "use client" directive.
	•	Cleaned up classNames for clarity and consistency.
